### PR TITLE
Retry markdown-link-check on failure 

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/workflows/markdown-links.yml
+++ b/.github/workflows/markdown-links.yml
@@ -10,12 +10,5 @@ jobs:
   markdown-link-check:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-
-      - name: Test links (retry enabled)
-        uses: Wandalen/wretry.action@v1.0.36
-        with:
-          action: gaurav-nelson/github-action-markdown-link-check@v1
-          attempt_limit: 3
-          attempt_delay: 5000
+      - uses: actions/checkout@v3
+      - uses: gaurav-nelson/github-action-markdown-link-check@v1

--- a/.github/workflows/markdown-links.yml
+++ b/.github/workflows/markdown-links.yml
@@ -2,8 +2,6 @@ name: Check Markdown links
 
 on:
   push:
-    branches:
-      - master
   pull_request:
   schedule:
     - cron: '15 0,12 * * *'
@@ -12,5 +10,12 @@ jobs:
   markdown-link-check:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - uses: gaurav-nelson/github-action-markdown-link-check@v1
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Test links (retry enabled)
+        uses: Wandalen/wretry.action@v1.0.36
+        with:
+          action: gaurav-nelson/github-action-markdown-link-check@v1
+          attempt_limit: 3
+          attempt_delay: 5000

--- a/README.md
+++ b/README.md
@@ -576,8 +576,9 @@ control).
 **The main work I&rsquo;ve done to try and eliminate that lag is on the `async`
 branch.** I refactored much of the overall design of the code (though not most
 of the lower-level details) and also made some parts
-[asynchronous](https://docs.microsoft.com/en-us/dotnet/csharp/async). This
-produced some improvement, but there was still sometimes some lag.
+<!-- FIXME: Link temporarily broken for testing. Fix link after testing. -->
+[asynchronous](https://docs.microsoft.com/en-us/dotnet/csharp/asyncq).
+This produced some improvement, but there was still sometimes some lag.
 
 On that branch, I also added two other features:
 

--- a/README.md
+++ b/README.md
@@ -539,7 +539,8 @@ page](https://graphviz.org/credits/).
 
 ## Future Directions
 
-See also [Other Bugs](#other-bugs) above.
+<!-- FIXME: Link temporarily broken for testing. Fix link after testing. -->
+See also [Other Bugs](#other-bugsz) above.
 
 ### Graph generator redesign
 


### PR DESCRIPTION
I don't usually do this, but it often gets status 0 on:

https://www.csail.mit.edu/person/charles-e-leiserson

Instead of manually re-running the workflow, which I've been doing,
perhaps the retrying can be automated (and specific to the
link-testing step).