### PR TITLE
Upgrade markdown-link-check to 1.0.15

### DIFF
--- a/.github/workflows/markdown-links.yml
+++ b/.github/workflows/markdown-links.yml
@@ -11,4 +11,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - uses: gaurav-nelson/github-action-markdown-link-check@v1
+    - uses: gaurav-nelson/github-action-markdown-link-check@1.0.15


### PR DESCRIPTION
Maybe this will help with the status 0 problem? (See #2.)

Even if not, 1.0.15 is marked as a stable release.